### PR TITLE
 (angular-ui-router): Add component key to IState for Angular 1.5 support since angular-ui-router@1.0.0-alpha.1

### DIFF
--- a/angular-ui-router/angular-ui-router.d.ts
+++ b/angular-ui-router/angular-ui-router.d.ts
@@ -45,6 +45,10 @@ declare namespace angular.ui {
          */
         templateProvider?: Function | Array<string|Function>;
         /**
+         * String, component name
+         */
+        component?: string;
+        /**
          * A controller paired to the state. Function, annotated array or name as String
          */
         controller?: Function|string|Array<string|Function>;


### PR DESCRIPTION
Since alpha.1, you can set `component` if you are using Angular 1.5 (component syntax)
- https://github.com/angular-ui/ui-router/commit/1552032#diff-88c3a890af6d3ec8ea2d12478de74c21R304
- https://github.com/angular-ui/ui-router/issues/2627
